### PR TITLE
Allow site contents to use entire width

### DIFF
--- a/tripleosphinx/theme/tripleo/static/tweaks.css
+++ b/tripleosphinx/theme/tripleo/static/tweaks.css
@@ -3,8 +3,7 @@ body {
 }
 
 #header {
-  width: 950px;
-  margin: 0 auto;
+  margin-left: 30px;
   height: 140px;
 }
 
@@ -89,7 +88,6 @@ div.body {
 }
 
 div.document {
-  width: 960px;
   margin: 0 auto;
 }
 


### PR DESCRIPTION
Setting a limit on the width of the site content results in a lot
of unnecessary whitespace on widescreen monitors, and given how
crowded the cistatus page is getting it would be nice to make use
of that space.  These tweaks to the css allow the content to
stretch as necessary.