### PR TITLE
Add link for zuul queue

### DIFF
--- a/tripleosphinx/theme/tripleo/layout.html
+++ b/tripleosphinx/theme/tripleo/layout.html
@@ -16,6 +16,7 @@
       <li><a href="/reviews.html" title="Go to the TripleO code reviews page" class="link">Reviews</a></li>
       <li><a href="/cistatus.html" title="Go to the TripleO CI Jobs status page" class="link">CI Status</a></li>
       <li><a href="http://status-tripleoci.rhcloud.com/" title="Go to the TripleO CI Extended status page" class="link">CI Extended</a></li>
+      <li><a href="http://zuul-status.nemebean.com/" title="Go to the Zuul TripleO Queue status page" class="link">Zuul Queue</a></li>
       <li><a href="/planet.html" title="Go to the TripleO Planet" class="link">Planet</a></li>
       {% endblock %}
     </ul>


### PR DESCRIPTION
Very useful for developers to find out the Zuul queue status for TripleO
jobs (OVB).